### PR TITLE
Ajout du convertisseur GTFS vers NeTEx (beta)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN cargo build --release
 RUN strip ./target/release/main
 
 # https://github.com/CanalTP/transit_model/tree/master/gtfs2netexfr (rust app)
+WORKDIR /
+RUN git clone --depth=1 --branch=master --single-branch https://github.com/CanalTP/transit_model
+WORKDIR /transit_model
 FROM ubuntu:focal
 COPY --from=builder /gtfs-to-geojson/target/release/gtfs-geojson /usr/local/bin/gtfs-geojson
 COPY --from=builder /transport-validator/target/release/main /usr/local/bin/transport-validator

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,10 @@ RUN strip ./target/release/main
 # - relying on https://hub.docker.com/r/kisiodigital/rust-ci, which provides a `proj` flavour (see
 #   https://github.com/CanalTP/ci-images/blob/master/rust/proj/Dockerfile)
 #
-# We could also probably just grab the `proj-ci` artefacts with a bit more time here https://hub.docker.com/r/kisiodigital/proj-ci
-# in the future if needed.
+# We could also probably "just" grab the `proj-ci` artefacts with a bit more time here:
+# - https://hub.docker.com/r/kisiodigital/proj-ci
+# - https://github.com/CanalTP/ci-images
+#
 FROM kisiodigital/rust-ci:latest-proj8.1.0 as builder_proj
 WORKDIR /
 RUN git clone --depth=1 --branch=master --single-branch https://github.com/CanalTP/transit_model

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,3 +47,6 @@ RUN apt-get -y install curl
 RUN curl --location -O https://github.com/MobilityData/gtfs-validator/releases/download/v2.0.0/gtfs-validator-v2.0.0_cli.jar 
 # https://github.com/CUTR-at-USF/gtfs-realtime-validator/blob/master/gtfs-realtime-validator-lib/README.md#batch-processing (java app)
 RUN curl --location -O https://s3.amazonaws.com/gtfs-rt-validator/travis_builds/gtfs-realtime-validator-lib/1.0.0-SNAPSHOT/gtfs-realtime-validator-lib-1.0.0-SNAPSHOT.jar
+
+COPY --from=builder_proj /usr/lib/libproj.* /usr/lib
+RUN /usr/local/bin/gtfs2netexfr --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,5 +50,7 @@ RUN curl --location -O https://github.com/MobilityData/gtfs-validator/releases/d
 # https://github.com/CUTR-at-USF/gtfs-realtime-validator/blob/master/gtfs-realtime-validator-lib/README.md#batch-processing (java app)
 RUN curl --location -O https://s3.amazonaws.com/gtfs-rt-validator/travis_builds/gtfs-realtime-validator-lib/1.0.0-SNAPSHOT/gtfs-realtime-validator-lib-1.0.0-SNAPSHOT.jar
 
+# for gtfs2netexfr
+RUN apt-get -y install libtiff5 libcurl3-nss
 COPY --from=builder_proj /usr/lib/libproj.* /usr/lib
 RUN /usr/local/bin/gtfs2netexfr --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN strip ./target/release/main
 WORKDIR /
 RUN git clone --depth=1 --branch=master --single-branch https://github.com/CanalTP/transit_model
 WORKDIR /transit_model
+RUN cargo build --manifest-path=gtfs2netexfr/Cargo.toml --release
 FROM ubuntu:focal
 COPY --from=builder /gtfs-to-geojson/target/release/gtfs-geojson /usr/local/bin/gtfs-geojson
 COPY --from=builder /transport-validator/target/release/main /usr/local/bin/transport-validator

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,5 +52,6 @@ RUN curl --location -O https://s3.amazonaws.com/gtfs-rt-validator/travis_builds/
 
 # for gtfs2netexfr
 RUN apt-get -y install libtiff5 libcurl3-nss
+# hackish ; TODO: check out https://github.com/CanalTP/ci-images instead
 COPY --from=builder_proj /usr/lib/libproj.* /usr/lib
 RUN /usr/local/bin/gtfs2netexfr --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ WORKDIR /transport-validator
 RUN cargo build --release
 RUN strip ./target/release/main
 
+# https://github.com/CanalTP/transit_model/tree/master/gtfs2netexfr (rust app)
 FROM ubuntu:focal
 COPY --from=builder /gtfs-to-geojson/target/release/gtfs-geojson /usr/local/bin/gtfs-geojson
 COPY --from=builder /transport-validator/target/release/main /usr/local/bin/transport-validator

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,12 @@ WORKDIR /
 RUN git clone --depth=1 --branch=master --single-branch https://github.com/CanalTP/transit_model
 WORKDIR /transit_model
 RUN cargo build --manifest-path=gtfs2netexfr/Cargo.toml --release
+# TODO: verify if proj must be added manually (most likely) on CI build
+# TODO: verify correct output path
+# TODO: strip the binary
+# TODO: copy to the right place
+# TODO: add basic test
+
 FROM ubuntu:focal
 COPY --from=builder /gtfs-to-geojson/target/release/gtfs-geojson /usr/local/bin/gtfs-geojson
 COPY --from=builder /transport-validator/target/release/main /usr/local/bin/transport-validator

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,10 @@ RUN curl --location -O https://s3.amazonaws.com/gtfs-rt-validator/travis_builds/
 RUN apt-get -y install libtiff5 libcurl3-nss
 # hackish ; TODO: check out https://github.com/CanalTP/ci-images instead
 COPY --from=builder_proj /usr/lib/libproj.* /usr/lib
+
+# run each binary (as part of CI) to make sure they do not lack a dynamic dependency
+RUN /usr/local/bin/gtfs-geojson --help
+RUN /usr/local/bin/transport-validator --help
 RUN /usr/local/bin/gtfs2netexfr --help
+
+# TODO: test java binaries (they do not have a `--help` currently I believe)

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,19 +16,30 @@ RUN cargo build --release
 RUN strip ./target/release/main
 
 # https://github.com/CanalTP/transit_model/tree/master/gtfs2netexfr (rust app)
+# We need `proj` to be installed for the `proj_sys` crate to compile. The various options considered were:
+# - `apt-get install proj-bin` (compilation fails with error `pkg-config` won't find `proj.pc`)
+# - `apt-get install libproj-dev` (compilation fails because this install proj 7 and we need proj >= 8)
+# - `make install_proj[_deps]` (https://github.com/CanalTP/transit_model/blob/master/Makefile) ; it works if we
+#   add `apt-get install sudo` which is missing, but takes a very long time at the moment
+# - relying on https://hub.docker.com/r/kisiodigital/rust-ci, which provides a `proj` flavour (see
+#   https://github.com/CanalTP/ci-images/blob/master/rust/proj/Dockerfile)
+#
+# We could also probably just grab the `proj-ci` artefacts with a bit more time here https://hub.docker.com/r/kisiodigital/proj-ci
+# in the future if needed.
+FROM kisiodigital/rust-ci:latest-proj8.1.0 as builder_proj
 WORKDIR /
 RUN git clone --depth=1 --branch=master --single-branch https://github.com/CanalTP/transit_model
 WORKDIR /transit_model
-RUN cargo build --manifest-path=gtfs2netexfr/Cargo.toml --release
-# TODO: verify if proj must be added manually (most likely) on CI build
-# TODO: verify correct output path
-# TODO: strip the binary
-# TODO: copy to the right place
-# TODO: add basic test
+# NOTE: when using the kisio rust-ci as a base image, CARGO_TARGET_DIR is set to something like `/tmp/cargo-release`.
+# To avoid breaking the build in case of variable change upstream, we instead force the build to be local, which
+# makes the COPY step in the next stage more reliable too. Useful debugging tips including `RUN env`, and adding `--verbose`
+RUN CARGO_TARGET_DIR=./target cargo build --manifest-path=gtfs2netexfr/Cargo.toml --release
+RUN strip ./target/release/gtfs2netexfr
 
 FROM ubuntu:focal
 COPY --from=builder /gtfs-to-geojson/target/release/gtfs-geojson /usr/local/bin/gtfs-geojson
 COPY --from=builder /transport-validator/target/release/main /usr/local/bin/transport-validator
+COPY --from=builder_proj /transit_model/target/release/gtfs2netexfr /usr/local/bin/gtfs2netexfr
 RUN apt-get -y update && apt-get -y install libssl-dev
 RUN apt-get -y install default-jre
 RUN apt-get -y install curl

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repository contains a Docker setup to consolidate various converters and validators that we use or will use soon on [transport.data.gouv.fr](https://transport.data.gouv.fr):
 * https://github.com/rust-transit/gtfs-to-geojson.git
 * https://github.com/etalab/transport-validator.git
+* https://github.com/CanalTP/transit_model/tree/master/gtfs2netexfr
 * https://github.com/MobilityData/gtfs-validator
 * https://github.com/CUTR-at-USF/gtfs-realtime-validator/blob/master/gtfs-realtime-validator-lib/README.md#batch-processing
 
@@ -41,6 +42,9 @@ docker run -a stdout -t localtest /usr/local/bin/gtfs-geojson --help
 
 # https://github.com/etalab/transport-validator.git
 docker run -a stdout -t localtest /usr/local/bin/transport-validator --help
+
+# https://github.com/CanalTP/transit_model/tree/master/gtfs2netexfr
+docker run -a stdout -t localtest /usr/local/bin/gtfs2netexfr --help
 
 # https://github.com/MobilityData/gtfs-validator/tree/v2.0.0-docs
 docker run -a stdout -t localtest java -jar gtfs-validator-v2.0.0_cli.jar

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ docker run -a stdout -t localtest /usr/local/bin/transport-validator --help
 # https://github.com/CanalTP/transit_model/tree/master/gtfs2netexfr
 docker run -a stdout -t localtest /usr/local/bin/gtfs2netexfr --help
 
-# actual run
-mkdir data
+# actual run, using a "data" subfolder shared with the docker machine (requires curl 7.73+)
+curl --create-dirs --output-dir ./data -O https://data.angers.fr/api/datasets/1.0/angers-loire-metropole-horaires-reseau-irigo-gtfs-rt/alternative_exports/irigo_gtfs_zip
 docker run -a stdout -a stderr -v $(pwd)/data:/data -t localtest /usr/local/bin/gtfs2netexfr -i /data/irigo_gtfs_zip -o /data --participant test
 
 # https://github.com/MobilityData/gtfs-validator/tree/v2.0.0-docs

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ docker run -a stdout -t localtest /usr/local/bin/transport-validator --help
 # https://github.com/CanalTP/transit_model/tree/master/gtfs2netexfr
 docker run -a stdout -t localtest /usr/local/bin/gtfs2netexfr --help
 
+# actual run
+mkdir data
+docker run -a stdout -a stderr -v $(pwd)/data:/data -t localtest /usr/local/bin/gtfs2netexfr -i /data/irigo_gtfs_zip -o /data --participant test
+
 # https://github.com/MobilityData/gtfs-validator/tree/v2.0.0-docs
 docker run -a stdout -t localtest java -jar gtfs-validator-v2.0.0_cli.jar
 


### PR DESCRIPTION
Ça n'a pas été simple, du fait de la présence de la librairie `proj` qui introduit une vraie complexité de compilation.

Je m'appuie pour l'instant sur une image `rust-ci` spécifique fournie par Kisio Digital (merci !), dont une variante dispose de `proj`. Voir:
- https://hub.docker.com/r/kisiodigital/rust-ci
- https://github.com/CanalTP/ci-images/blob/master/rust/proj/Dockerfile

On pourrait plus tard alléger le dispositif en allant chercher uniquement les "artefacts" pour rust via https://hub.docker.com/r/kisiodigital/proj-ci, mais ça semble faire le travail.

### Point restants

- [x] `❯ docker run -a stdout -t localtest /usr/local/bin/gtfs2netexfr --help
/usr/local/bin/gtfs2netexfr: error while loading shared libraries: libproj.so.22: cannot open shared object file: No such file or directory`
- [x] Pareil sur "libtiff"

### Note qualité

À considérer comme une beta : il y a des warnings sur "proj.db", je vais shipper en les ignorant, mais on verra si ça pose problème durant les tests (voir https://github.com/etalab/transport-tools/issues/10).

### Note sécurité 

Du coup on est dépendant d'un point de vue sécurité de ce qui est fait sur la publication des images là-bas, au moins pour l'instant.

Je pense préférable à terme de recompiler notre propre image pour réduire un peu la surface d'attaque, car ce n'est pas très compliqué, et peu fréquent.

Voir ticket https://github.com/etalab/transport_deploy/issues/47