### PR TITLE
Versionner l'image transport-tools

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,9 @@
 # - https://docs.github.com/en/actions/guides/publishing-docker-images#publishing-images-to-github-packages
 name: Create and publish a Docker image
 on:
+  # See https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-object-38
+  release:
+    types: [ published ]
   push:
     branches:
       - master


### PR DESCRIPTION
Cf https://github.com/etalab/transport-ops/pull/34 ça devient utile d'avoir une notion de "release" ici, avec un numéro de version pour `transport-tools`, qui pourra ainsi être référencé dans l'image principale de l'application.

Je vais voir si je peux arriver à faire ça simplement ici, en améliorant le workflow GitHub actions.