### PR TITLE
Copie du dossier /usr/share/proj/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ RUN curl --location -O https://s3.amazonaws.com/gtfs-rt-validator/travis_builds/
 RUN apt-get -y install libtiff5 libcurl3-nss
 # hackish ; TODO: check out https://github.com/CanalTP/ci-images instead
 COPY --from=builder_proj /usr/lib/libproj.* /usr/lib
+# home of proj.db
+COPY --from=builder_proj /usr/share/proj/ /usr/share/proj/
 
 # run each binary (as part of CI) to make sure they do not lack a dynamic dependency
 RUN /usr/local/bin/gtfs-geojson --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get -y install libtiff5 libcurl3-nss
 # hackish ; TODO: check out https://github.com/CanalTP/ci-images instead
 COPY --from=builder_proj /usr/lib/libproj.* /usr/lib
 # home of proj.db
+RUN mkdir /usr/share/proj/
 COPY --from=builder_proj /usr/share/proj/ /usr/share/proj/
 
 # run each binary (as part of CI) to make sure they do not lack a dynamic dependency


### PR DESCRIPTION
Depuis le container de Kisio.
C'est là que réside la base proj.db, dont on a besoin lors de la conversion GTFS => NeTEx.