### PR TITLE
Mise à disposition validateur MobilityData GTFS v3 + freezing des versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,8 @@ RUN apt-get -y update && apt-get -y install libssl-dev
 RUN apt-get -y install default-jre
 RUN apt-get -y install curl
 # https://github.com/MobilityData/gtfs-validator (java app)
-RUN curl --location -O https://github.com/MobilityData/gtfs-validator/releases/download/v2.0.0/gtfs-validator-v2.0.0_cli.jar 
+# https://github.com/MobilityData/gtfs-validator/releases
+RUN curl --location -O https://github.com/MobilityData/gtfs-validator/releases/download/v3.0.0/gtfs-validator-v3.0.0_cli.jar
 # https://github.com/CUTR-at-USF/gtfs-realtime-validator/blob/master/gtfs-realtime-validator-lib/README.md#batch-processing (java app)
 RUN curl --location -O https://s3.amazonaws.com/gtfs-rt-validator/travis_builds/gtfs-realtime-validator-lib/1.0.0-SNAPSHOT/gtfs-realtime-validator-lib-1.0.0-SNAPSHOT.jar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libssl-dev default-jre cur
 # https://github.com/MobilityData/gtfs-validator (java app)
 # https://github.com/MobilityData/gtfs-validator/releases
 RUN curl --location -O https://github.com/MobilityData/gtfs-validator/releases/download/v3.0.0/gtfs-validator-v3.0.0_cli.jar
+RUN cp gtfs-validator-v3.0.0_cli.jar /usr/local/bin
+
 # https://github.com/CUTR-at-USF/gtfs-realtime-validator/blob/master/gtfs-realtime-validator-lib/README.md#batch-processing (java app)
 # freeze by commit + self-compile for now (https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/406)
 RUN git clone https://github.com/CUTR-at-USF/gtfs-realtime-validator.git
@@ -79,6 +81,6 @@ RUN /usr/local/bin/transport-validator --help
 RUN /usr/local/bin/gtfs2netexfr --help
 
 # the --help returns a non-zero exit code ; we grep on a well-known text as a quick test
-RUN java -jar gtfs-validator-v3.0.0_cli.jar --help | grep "Location of the input GTFS ZIP"
-
-# TODO: test java binaries (they do not have a `--help` currently I believe)
+RUN java -jar /usr/local/bin/gtfs-validator-v3.0.0_cli.jar --help | grep "Location of the input GTFS ZIP"
+# there is no --version or --help here currently
+RUN java -jar /usr/local/bin/gtfs-realtime-validator-lib-1.0.0-SNAPSHOT.jar 2>&1 | grep "For batch mode you must provide a path and file name to GTFS data"

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,10 @@ FROM ubuntu:focal
 COPY --from=builder /gtfs-to-geojson/target/release/gtfs-geojson /usr/local/bin/gtfs-geojson
 COPY --from=builder /transport-validator/target/release/main /usr/local/bin/transport-validator
 COPY --from=builder_proj /transit_model/target/release/gtfs2netexfr /usr/local/bin/gtfs2netexfr
-RUN apt-get -y update && apt-get -y install libssl-dev
-RUN apt-get -y install default-jre
-RUN apt-get -y install curl
+
+RUN apt-get -y update
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libssl-dev default-jre curl git
+
 # https://github.com/MobilityData/gtfs-validator (java app)
 # https://github.com/MobilityData/gtfs-validator/releases
 RUN curl --location -O https://github.com/MobilityData/gtfs-validator/releases/download/v3.0.0/gtfs-validator-v3.0.0_cli.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,3 +84,5 @@ RUN /usr/local/bin/gtfs2netexfr --help
 RUN java -jar /usr/local/bin/gtfs-validator-v3.0.0_cli.jar --help | grep "Location of the input GTFS ZIP"
 # there is no --version or --help here currently
 RUN java -jar /usr/local/bin/gtfs-realtime-validator-lib-1.0.0-SNAPSHOT.jar 2>&1 | grep "For batch mode you must provide a path and file name to GTFS data"
+# freeze the JDK too (installed via default-jre, so no explicit version)
+RUN java -version | grep "openjdk 11 "

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,4 +69,7 @@ RUN /usr/local/bin/gtfs-geojson --help
 RUN /usr/local/bin/transport-validator --help
 RUN /usr/local/bin/gtfs2netexfr --help
 
+# the --help returns a non-zero exit code ; we grep on a well-known text as a quick test
+RUN java -jar gtfs-validator-v3.0.0_cli.jar --help | grep "Location of the input GTFS ZIP"
+
 # TODO: test java binaries (they do not have a `--help` currently I believe)

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,4 +85,4 @@ RUN java -jar /usr/local/bin/gtfs-validator-v3.0.0_cli.jar --help | grep "Locati
 # there is no --version or --help here currently
 RUN java -jar /usr/local/bin/gtfs-realtime-validator-lib-1.0.0-SNAPSHOT.jar 2>&1 | grep "For batch mode you must provide a path and file name to GTFS data"
 # freeze the JDK too (installed via default-jre, so no explicit version)
-RUN java -version | grep "OpenJDK Runtime Environment (build 11."
+RUN java -version 2>&1 | grep "OpenJDK Runtime Environment (build 11."

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM ubuntu:focal
 # https://github.com/rust-transit/gtfs-to-geojson.git (rust app)
 FROM rust:latest as builder
 WORKDIR /
-RUN git clone --depth=1 --branch main --single-branch https://github.com/rust-transit/gtfs-to-geojson.git
+# this repo has no tagged releases ; we pin the version based on latest verified commit instead
+RUN git clone https://github.com/rust-transit/gtfs-to-geojson.git
+RUN git -C gtfs-to-geojson checkout 3f21e496e433704cf879ee453eaa4cb41cf06e7c
 WORKDIR /gtfs-to-geojson
 RUN cargo build --release
 RUN strip ./target/release/gtfs-geojson

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN strip ./target/release/gtfs-geojson
 
 # https://github.com/etalab/transport-validator.git (rust app)
 WORKDIR /
-RUN git clone --depth=1 --branch=master --single-branch https://github.com/etalab/transport-validator.git
+# this repo has no tagged releases ; we pin the version based on latest verified commit instead
+RUN git clone https://github.com/etalab/transport-validator.git
+RUN git -C transport-validator checkout 302e62e787dc28b80f9e8e80ceadc80be71aafbc
 WORKDIR /transport-validator
 RUN cargo build --release
 RUN strip ./target/release/main

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,4 +85,4 @@ RUN java -jar /usr/local/bin/gtfs-validator-v3.0.0_cli.jar --help | grep "Locati
 # there is no --version or --help here currently
 RUN java -jar /usr/local/bin/gtfs-realtime-validator-lib-1.0.0-SNAPSHOT.jar 2>&1 | grep "For batch mode you must provide a path and file name to GTFS data"
 # freeze the JDK too (installed via default-jre, so no explicit version)
-RUN java -version | grep "openjdk 11 "
+RUN java -version | grep "OpenJDK Runtime Environment (build 11."

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN strip ./target/release/main
 #
 FROM kisiodigital/rust-ci:latest-proj8.1.0 as builder_proj
 WORKDIR /
-RUN git clone --depth=1 --branch=master --single-branch https://github.com/CanalTP/transit_model
+# we pin the version to avoid unexpected changes due to rebuild on our side
+RUN git clone --depth=1 --branch=v0.46.0 --single-branch https://github.com/CanalTP/transit_model
 WORKDIR /transit_model
 # NOTE: when using the kisio rust-ci as a base image, CARGO_TARGET_DIR is set to something like `/tmp/cargo-release`.
 # To avoid breaking the build in case of variable change upstream, we instead force the build to be local, which

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,15 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libssl-dev default-jre cur
 # https://github.com/MobilityData/gtfs-validator/releases
 RUN curl --location -O https://github.com/MobilityData/gtfs-validator/releases/download/v3.0.0/gtfs-validator-v3.0.0_cli.jar
 # https://github.com/CUTR-at-USF/gtfs-realtime-validator/blob/master/gtfs-realtime-validator-lib/README.md#batch-processing (java app)
-RUN curl --location -O https://s3.amazonaws.com/gtfs-rt-validator/travis_builds/gtfs-realtime-validator-lib/1.0.0-SNAPSHOT/gtfs-realtime-validator-lib-1.0.0-SNAPSHOT.jar
+# freeze by commit + self-compile for now (https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/406)
+RUN git clone https://github.com/CUTR-at-USF/gtfs-realtime-validator.git
+RUN git -C gtfs-realtime-validator checkout fca9c73b3d3b377c606065648750b777d36ad553
+WORKDIR /gtfs-realtime-validator/gtfs-realtime-validator-lib
+RUN apt-get -y install maven
+RUN mvn package
+RUN cp target/gtfs-realtime-validator-lib-1.0.0-SNAPSHOT.jar /usr/local/bin
+
+WORKDIR /
 
 # for gtfs2netexfr
 RUN apt-get -y install libtiff5 libcurl3-nss


### PR DESCRIPTION
Dans cette PR, je fais des améliorations pour que les builds soient plus déterministes. Il est important que quand on déclenche une build, la version d'un outil tiers (validateur ou convertisseur) ne change pas sans qu'on en soit conscient, et qu'on puisse contrôler le rythme d'upgrade, sans quoi on pourrait dégrader des fonctionnalités ou se retrouver à devoir corriger des bugs dans l'urgence.

En détail, je freeze les versions de:
- https://github.com/rust-transit/gtfs-to-geojson.git (par commit car pas de releases)
- https://github.com/etalab/transport-validator.git (par commit aussi)
- https://github.com/CanalTP/transit_model (par release GitHub)
- https://github.com/CUTR-at-USF/gtfs-realtime-validator/blob/master/gtfs-realtime-validator-lib/README.md#batch-processing (le binaire est un snapshot de build, j'ai préféré le freezer par commit et le compiler, ce qui va assez vite ; il faudra vérifier que je n'ai pas introduit de problème, et on pourra rebasculer sur des builds officielles quand il y en aura https://github.com/CUTR-at-USF/gtfs-realtime-validator/issues/406)

Par ailleurs:
- Je migre https://github.com/MobilityData/gtfs-validator de la version 2 à la version 3 (sortie il y a 2 semaines) #7
- J'ajoute des tests runtime pour vérifier l'exécution des jars
- Les jars sont à présent placés dans `/usr/local/bin` également, j'ai lu que c'était pas un mauvais endroit pour ça
